### PR TITLE
Laboratorium 1 - zadanie 3.2

### DIFF
--- a/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/DrawPanelAdapter.java
+++ b/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/DrawPanelAdapter.java
@@ -9,10 +9,10 @@ import edu.kis.powp.jobs2d.features.DrawerFeature;
 /**
  * driver adapter to drawer with several bugs.
  */
-public class MyAdapter extends DrawPanelController implements Job2dDriver {
+public class DrawPanelAdapter extends DrawPanelController implements Job2dDriver {
 	private int startX = 0, startY = 0;
 
-	public MyAdapter() {
+	public DrawPanelAdapter() {
 		super();
 	}
 

--- a/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/MyAdapter.java
+++ b/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/MyAdapter.java
@@ -27,6 +27,8 @@ public class MyAdapter extends DrawPanelController implements Job2dDriver {
 		line.setStartCoordinates(this.startX, this.startY);
 		line.setEndCoordinates(x, y);
 
+		setPosition(x, y);
+
 		drawLine(line);
 	}
 

--- a/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/MyAdapter.java
+++ b/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/MyAdapter.java
@@ -4,6 +4,7 @@ import edu.kis.legacy.drawer.panel.DrawPanelController;
 import edu.kis.legacy.drawer.shape.ILine;
 import edu.kis.legacy.drawer.shape.LineFactory;
 import edu.kis.powp.jobs2d.Job2dDriver;
+import edu.kis.powp.jobs2d.features.DrawerFeature;
 
 /**
  * driver adapter to drawer with several bugs.
@@ -29,7 +30,7 @@ public class MyAdapter extends DrawPanelController implements Job2dDriver {
 
 		setPosition(x, y);
 
-		drawLine(line);
+		DrawerFeature.getDrawerController().drawLine(line);
 	}
 
 	@Override

--- a/src/test/java/edu/kis/powp/jobs2d/TestJobs2dPatterns.java
+++ b/src/test/java/edu/kis/powp/jobs2d/TestJobs2dPatterns.java
@@ -83,7 +83,7 @@ public class TestJobs2dPatterns {
 			public void run() {
 				Application app = new Application("2d jobs Visio");
 				DrawerFeature.setupDrawerPlugin(app);
-				setupDefaultDrawerVisibilityManagement(app);
+//				setupDefaultDrawerVisibilityManagement(app);
 
 				DriverFeature.setupDriverPlugin(app);
 				setupDrivers(app);

--- a/src/test/java/edu/kis/powp/jobs2d/TestJobs2dPatterns.java
+++ b/src/test/java/edu/kis/powp/jobs2d/TestJobs2dPatterns.java
@@ -8,7 +8,7 @@ import java.util.logging.Logger;
 import edu.kis.legacy.drawer.panel.DefaultDrawerFrame;
 import edu.kis.legacy.drawer.panel.DrawPanelController;
 import edu.kis.powp.appbase.Application;
-import edu.kis.powp.jobs2d.drivers.adapter.MyAdapter;
+import edu.kis.powp.jobs2d.drivers.adapter.DrawPanelAdapter;
 import edu.kis.powp.jobs2d.events.SelectChangeVisibleOptionListener;
 import edu.kis.powp.jobs2d.events.SelectTestFigureOptionListener;
 import edu.kis.powp.jobs2d.features.DrawerFeature;
@@ -39,7 +39,7 @@ public class TestJobs2dPatterns {
 		DriverFeature.addDriver("Logger Driver", loggerDriver);
 		DriverFeature.getDriverManager().setCurrentDriver(loggerDriver);
 
-		Job2dDriver testDriver = new MyAdapter();
+		Job2dDriver testDriver = new DrawPanelAdapter();
 		DriverFeature.addDriver("Buggy Simulator", testDriver);
 
 		DriverFeature.updateDriverInfo();

--- a/src/test/java/edu/kis/powp/jobs2d/TestJobs2dPatterns.java
+++ b/src/test/java/edu/kis/powp/jobs2d/TestJobs2dPatterns.java
@@ -46,18 +46,6 @@ public class TestJobs2dPatterns {
 	}
 
 	/**
-	 * Auxiliary routines to enable using Buggy Simulator.
-	 * 
-	 * @param application Application context.
-	 */
-	private static void setupDefaultDrawerVisibilityManagement(Application application) {
-		DefaultDrawerFrame defaultDrawerWindow = DefaultDrawerFrame.getDefaultDrawerFrame();
-		application.addComponentMenuElementWithCheckBox(DrawPanelController.class, "Default Drawer Visibility",
-				new SelectChangeVisibleOptionListener(defaultDrawerWindow), true);
-		defaultDrawerWindow.setVisible(true);
-	}
-
-	/**
 	 * Setup menu for adjusting logging settings.
 	 * 
 	 * @param application Application context.
@@ -83,7 +71,6 @@ public class TestJobs2dPatterns {
 			public void run() {
 				Application app = new Application("2d jobs Visio");
 				DrawerFeature.setupDrawerPlugin(app);
-//				setupDefaultDrawerVisibilityManagement(app);
 
 				DriverFeature.setupDriverPlugin(app);
 				setupDrivers(app);


### PR DESCRIPTION
Poprawa błędów:
- symulacja otwiera się w dodatkowym oknie
- zły wzór symulacji
- nieprecyzyjna nazwy klas